### PR TITLE
fix: support prompt-only user rating evals

### DIFF
--- a/cmd/lmx/main.go
+++ b/cmd/lmx/main.go
@@ -6051,9 +6051,11 @@ func handleEvalRun(suiteSlug string, args cliArgs) error {
 		"executionMode": map[bool]string{true: "CUSTOM_LOCAL", false: "LM_EVAL_LOCAL"}[strings.EqualFold(runner, "CUSTOM")],
 		"judgeMode":     map[bool]string{true: "LOCAL_REPORTED", false: "NONE"}[strings.EqualFold(stringValue(doc["scoringMethod"]), "llm_judge")],
 		"runnerVersion": map[bool]string{true: "localmaxxing-go custom-local", false: "localmaxxing-go lm-eval-upload"}[strings.EqualFold(runner, "CUSTOM")],
-		"results":       result["scores"],
 		"artifacts":     redactGold(result["artifacts"]),
 		"runConfig":     map[string]any{"aggregatePreview": result["aggregate"]},
+	}
+	if !strings.EqualFold(stringValue(doc["scoringMethod"]), "user_rating") {
+		payload["results"] = result["scores"]
 	}
 	if hardwarePath := opt(args, "hardware"); hardwarePath != "" {
 		hardware, err := readJSON(hardwarePath)
@@ -6428,12 +6430,21 @@ func runCustomLocalEval(suite map[string]any, args cliArgs) (map[string]any, err
 	flatScores := map[string]float64{}
 	artifacts := []any{}
 	for _, task := range evalTasks(doc) {
-		if stringValue(task["promptTemplate"]) == "" || asObject(task["dataset"]) == nil {
-			return nil, cliError{"task_not_runnable", fmt.Sprintf("Task %q requires promptTemplate and dataset", stringValue(task["key"])), []string{"Fix the suite JSON or use an LM_EVAL_HARNESS suite for external lm-eval tasks."}, nil}
+		if stringValue(task["promptTemplate"]) == "" {
+			return nil, cliError{"task_not_runnable", fmt.Sprintf("Task %q requires promptTemplate", stringValue(task["key"])), []string{"Fix the suite JSON or use an LM_EVAL_HARNESS suite for external lm-eval tasks."}, nil}
 		}
-		items, err := loadEvalDataset(asObject(task["dataset"]))
-		if err != nil {
-			return nil, cliError{"dataset_load_failed", fmt.Sprintf("Failed to load dataset for task %q: %v", stringValue(task["key"]), err), []string{"Check dataset source fields and network access."}, nil}
+		var items []map[string]any
+		if asObject(task["dataset"]) == nil {
+			if strings.EqualFold(scoring, "user_rating") {
+				items = []map[string]any{{}}
+			} else {
+				return nil, cliError{"task_not_runnable", fmt.Sprintf("Task %q requires dataset", stringValue(task["key"])), []string{"Fix the suite JSON or use an LM_EVAL_HARNESS suite for external lm-eval tasks."}, nil}
+			}
+		} else {
+			items, err = loadEvalDataset(asObject(task["dataset"]))
+			if err != nil {
+				return nil, cliError{"dataset_load_failed", fmt.Sprintf("Failed to load dataset for task %q: %v", stringValue(task["key"]), err), []string{"Check dataset source fields and network access."}, nil}
+			}
 		}
 		totalScore := 0.0
 		counted := 0
@@ -6445,11 +6456,15 @@ func runCustomLocalEval(suite map[string]any, args cliArgs) (map[string]any, err
 			response, err := callOpenAIChat(baseURL, model, prompt, opt(args, "model-api-key"), int(firstNonZero(int(numberField(task, "maxNewTokens")), 256)), evalTemperature(doc), evalTopP(doc), stringSlice(task["stopSequences"]))
 			if err == nil {
 				artifact["response"] = response
-				var score float64
-				score, artifact, err = scoreCustomEvalItem(scoring, task, item, response, prompt, artifact, judgeBaseURL, judgeModel, judgeAPIKey)
-				if err == nil {
-					totalScore += score
-					artifact["score"] = score
+				if strings.EqualFold(scoring, "user_rating") {
+					artifact["scorePending"] = true
+				} else {
+					var score float64
+					score, artifact, err = scoreCustomEvalItem(scoring, task, item, response, prompt, artifact, judgeBaseURL, judgeModel, judgeAPIKey)
+					if err == nil {
+						totalScore += score
+						artifact["score"] = score
+					}
 				}
 			}
 			if err != nil {
@@ -6460,7 +6475,7 @@ func runCustomLocalEval(suite map[string]any, args cliArgs) (map[string]any, err
 			artifact["latencyMs"] = time.Since(started).Milliseconds()
 			artifacts = append(artifacts, artifact)
 		}
-		if counted > 0 {
+		if counted > 0 && !strings.EqualFold(scoring, "user_rating") {
 			score := totalScore / float64(counted)
 			scores[stringValue(task["key"])] = map[string]any{"score": score, "nSamples": counted, "nShots": numberField(task, "nShots")}
 			flatScores[stringValue(task["key"])] = score

--- a/cmd/lmx/main_test.go
+++ b/cmd/lmx/main_test.go
@@ -2077,3 +2077,107 @@ func TestDiscoverServerMetadata(t *testing.T) {
 		t.Fatalf("quantization = %v", meta["quantization"])
 	}
 }
+
+func TestRunCustomLocalEvalSupportsPromptOnlyUserRating(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		messages := anySlice(body["messages"])
+		if len(messages) != 1 || !strings.Contains(stringValue(asObject(messages[0])["content"]), "greenpost") {
+			t.Fatalf("messages = %#v", messages)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":">line one\n>line two\n>line three\n>line four\n>line five"}}]}`)
+	}))
+	defer srv.Close()
+
+	suite := map[string]any{
+		"slug":   "tech-greenpost-usereval",
+		"runner": "CUSTOM",
+		"suiteDoc": map[string]any{
+			"scoringMethod": "user_rating",
+			"tasks": []any{
+				map[string]any{
+					"key":            "greenpost",
+					"promptTemplate": "Write a greenpost",
+					"maxNewTokens":   1000,
+				},
+			},
+		},
+	}
+	result, err := runCustomLocalEval(suite, parseArgs([]string{"--model", "test/model", "--base-url", srv.URL}))
+	if err != nil {
+		t.Fatalf("runCustomLocalEval returned error: %v", err)
+	}
+	if len(asObject(result["scores"])) != 0 {
+		t.Fatalf("user_rating scores should be empty, got %#v", result["scores"])
+	}
+	artifacts := anySlice(result["artifacts"])
+	if len(artifacts) != 1 {
+		t.Fatalf("artifacts len = %d", len(artifacts))
+	}
+	artifact := asObject(artifacts[0])
+	if artifact["taskKey"] != "greenpost" || artifact["scorePending"] != true {
+		t.Fatalf("artifact = %#v", artifact)
+	}
+	if !strings.Contains(stringValue(artifact["response"]), ">line one") {
+		t.Fatalf("response = %q", artifact["response"])
+	}
+}
+
+func TestHandleEvalRunOmitsResultsForUserRatingPromptOnlySuite(t *testing.T) {
+	modelSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("unexpected model path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":">line one\n>line two\n>line three\n>line four\n>line five"}}]}`)
+	}))
+	defer modelSrv.Close()
+
+	suitePath := filepath.Join(t.TempDir(), "suite.json")
+	if err := writeJSON(suitePath, map[string]any{
+		"slug":   "tech-greenpost-usereval",
+		"runner": "CUSTOM",
+		"suiteDoc": map[string]any{
+			"scoringMethod": "user_rating",
+			"tasks": []any{
+				map[string]any{
+					"key":            "greenpost",
+					"promptTemplate": "Write a greenpost",
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("write suite: %v", err)
+	}
+	outPath := filepath.Join(t.TempDir(), "run.json")
+	err := handleEvalRun("tech-greenpost-usereval", parseArgs([]string{"--suite-file", suitePath, "--model", "test/model", "--base-url", modelSrv.URL, "--out", outPath}))
+	if err != nil {
+		t.Fatalf("handleEvalRun returned error: %v", err)
+	}
+	payload := asObject(mustReadJSONForTest(t, outPath))
+	if _, ok := payload["results"]; ok {
+		t.Fatalf("user_rating payload should omit results, got %#v", payload["results"])
+	}
+	if payload["judgeMode"] != "NONE" || payload["executionMode"] != "CUSTOM_LOCAL" {
+		t.Fatalf("payload modes = %#v", payload)
+	}
+	if len(anySlice(payload["artifacts"])) != 1 {
+		t.Fatalf("artifacts = %#v", payload["artifacts"])
+	}
+}
+
+func mustReadJSONForTest(t *testing.T, path string) any {
+	t.Helper()
+	value, err := readJSON(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return value
+}


### PR DESCRIPTION
## Summary

`lmx eval run` now supports CUSTOM `user_rating` suites that have a `promptTemplate` but no dataset — like the official `tech-greenpost-usereval`. Previously, these suites failed with `task_not_runnable`.

## Problem

Running the official suite:

```bash
lmx eval run tech-greenpost-usereval \
  --model Crownelius/The-Crow-9B-Creative-Writing-Opus4.6-DISTILL-Heretic \
  --base-url http://localhost:8080 \
  --hardware hardware.json
```

Produced:

```
[localmaxxing:error] task_not_runnable
Task "greenpost" requires promptTemplate and dataset
```

But the suite's `agentInstructions` and the LocalMaxxing API contract (`POST /api/evals/runs`) say user_rating suites should submit prompt/response artifacts with no local score. The `promptTemplate` is present in the suite doc — the CLI was rejecting it purely because no `dataset` object existed alongside it.

## Root cause

`runCustomLocalEval` required `promptTemplate` AND `dataset` for every custom task. It also unconditionally computed and embedded a local score, which `user_rating` suites should not report.

## Fix

Three changes in `cmd/lmx/main.go`:

1. **Prompt-only tasks allowed for `user_rating`.** If a task has a `promptTemplate` but no `dataset`, and `scoringMethod` is `user_rating`, synthesize a single empty item so exactly one artifact is generated.

2. **`scorePending` marker instead of local score.** When `scoringMethod` is `user_rating`, artifacts get `scorePending: true` and skip local scoring (`scoreCustomEvalItem` is not called).

3. **`results` omitted from eval-run payload for `user_rating`.** `handleEvalRun` omits the `results` key when `scoringMethod` is `user_rating`, matching the API contract that community ratings supply the score after approval.

Existing non-user-rating CUSTOM suites (exact_match, f1, llm_judge) and LM_EVAL_HARNESS suites are unchanged.

## Verification

```bash
# Unit tests
go test ./cmd/lmx -run "TestRunCustomLocalEvalSupportsPromptOnlyUserRating|TestHandleEvalRunOmitsResultsForUserRatingPromptOnlySuite"
# PASS

# Compile check
go build ./cmd/lmx
# PASS (no output)

# End-to-end with a running llama.cpp server and the official greenpost prompt template
lmx eval run tech-greenpost-usereval \
  --suite-file test-suite.json \
  --model Crownelius/The-Crow-9B-Creative-Writing-Opus4.6-DISTILL-Heretic \
  --base-url http://127.0.0.1:8080 \
  --hardware hardware.json \
  --out test-eval-run.json
# PASS — one artifact generated, scorePending: true, no results key, judgeMode: NONE
```

Output payload snippet:

```json
{
  "suiteSlug": "tech-greenpost-usereval",
  "executionMode": "CUSTOM_LOCAL",
  "judgeMode": "NONE",
  "artifacts": [{
    "taskKey": "greenpost",
    "itemIndex": 0,
    "prompt": "Write exactly one short technology-themed...",
    "response": "> The server farm hummed at 99% capacity...",
    "latencyMs": 88323,
    "scorePending": true
  }]
}
```

Note: `results` key is absent, as expected for user_rating.

## Notes

- Full package test (`go test ./cmd/lmx`) has unrelated baseline failures on this Windows machine (engine detection, auth config permissions on Windows, remote timing assumptions). None of the new targeted tests fail.
- The existing `llm_judge`, `exact_match`, and `f1` custom eval flows are unchanged: they still require datasets and still compute and embed local scores.
