### PR TITLE
fix: lm-eval dry-run exits without executing lm_eval

### DIFF
--- a/cmd/lmx/main.go
+++ b/cmd/lmx/main.go
@@ -6009,6 +6009,12 @@ func handleLmEval(suiteSlug string, args cliArgs) error {
 	}
 	cmdArgs = append(cmdArgs, "--output_path", resultsPath)
 	printInfo("lm_eval_start", map[string]any{"suite": suiteSlug, "command": command, "backend": backend, "modelArgs": modelArgs, "tasks": tasks, "output": resultsPath})
+	if hasFlag(args, "dry-run") {
+		printInfo("lm_eval_dry_run", map[string]any{"command": command, "args": cmdArgs, "suite": suiteSlug})
+		fmt.Printf("Dry-run: would execute:\n  %s %s\n", command, strings.Join(cmdArgs, " "))
+		fmt.Println("Remove --dry-run to execute.")
+		return nil
+	}
 	cmd := exec.Command(command, cmdArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/lmx/main_test.go
+++ b/cmd/lmx/main_test.go
@@ -2077,3 +2077,29 @@ func TestDiscoverServerMetadata(t *testing.T) {
 		t.Fatalf("quantization = %v", meta["quantization"])
 	}
 }
+
+func TestHandleLmEvalDryRunPrintsCommandAndExits(t *testing.T) {
+	// `handleLmEval` calls `exec.Command(lm_eval, ...)` when not in dry-run.
+	// Placing a fake lm_eval on PATH avoids exec errors in test.
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "lm_eval"))
+	oldPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+	defer os.Setenv("PATH", oldPath)
+
+	suitePath := filepath.Join(t.TempDir(), "suite.json")
+	if err := writeJSON(suitePath, map[string]any{
+		"slug":   "mmlu",
+		"runner": "LM_EVAL_HARNESS",
+		"suiteDoc": map[string]any{
+			"tasks": []any{map[string]any{"key": "mmlu", "nShots": 5}},
+		},
+	}); err != nil {
+		t.Fatalf("write suite: %v", err)
+	}
+
+	err := handleLmEval("mmlu", parseArgs([]string{"--suite-file", suitePath, "--model", "test/model", "--dry-run"}))
+	if err != nil {
+		t.Fatalf("handleLmEval dry-run returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`lmx eval lm-eval ... --dry-run` no longer launches `lm_eval`. It prints the planned command and exits.

## Problem

```bash
lmx eval lm-eval mmlu-5shot \
  --model Qwen/Qwen2.5-0.5B-Instruct \
  --backend hf \
  --hardware hardware.json \
  --dry-run
```

Previously, this started a full `lm_eval` run: loaded the model, built all MMLU contexts, and began 56,168 loglikelihood requests — consuming GPU time and making dry-run unusable for large suites.

## Root cause

`handleLmEval` built the lm_eval command args then unconditionally called `exec.Command(...).Run()` without checking the `--dry-run` flag.

## Fix

In `handleLmEval`, after constructing the command arguments but before `exec.Command`:

- Check `hasFlag(args, "dry-run")`.
- If set, print the planned `lm_eval` command with args, emit `lm_eval_dry_run` status, and return `nil` without executing.
- Otherwise, proceed with the existing execution path.

## Verification

```bash
# Unit test
go test ./cmd/lmx -run TestHandleLmEvalDryRunPrintsCommandAndExits -v
# PASS

# Compile check
go build ./cmd/lmx
# PASS

# End-to-end
lmx eval lm-eval mmlu-5shot \
  --model Qwen/Qwen2.5-0.5B-Instruct \
  --backend hf \
  --dry-run
# Prints:
#   [localmaxxing] lm_eval_dry_run
#     command: lm_eval
#     args: [--model hf --model_args pretrained=Qwen/Qwen2.5-0.5B-Instruct --tasks mmlu --output_path localmaxxing-lm-eval-results.json]
#   Dry-run: would execute:
#     lm_eval --model hf --model_args pretrained=Qwen/Qwen2.5-0.5B-Instruct --tasks mmlu --output_path localmaxxing-lm-eval-results.json
#   Remove --dry-run to execute.
# Wall time: 0.29s
```