### PR TITLE
Fix benchmark submit rejected for hardware.gpus[] using wrong key

### DIFF
--- a/cmd/lmx/main.go
+++ b/cmd/lmx/main.go
@@ -1378,7 +1378,7 @@ func applyNvidiaSMIHardware(base map[string]any, output string) {
 		if len(parts) < 2 {
 			continue
 		}
-		gpu := map[string]any{"name": strings.TrimSpace(parts[0])}
+		gpu := map[string]any{"gpuName": strings.TrimSpace(parts[0]), "count": 1}
 		if mb, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64); err == nil {
 			gpu["vramGb"] = round1(mb / 1024)
 			totalVramMb += mb
@@ -1391,7 +1391,7 @@ func applyNvidiaSMIHardware(base map[string]any, output string) {
 	base["hwClass"] = "DISCRETE_GPU"
 	base["gpuCount"] = len(gpus)
 	base["gpus"] = gpus
-	base["gpuName"] = gpus[0]["name"]
+	base["gpuName"] = gpus[0]["gpuName"]
 	if vramGb, ok := gpus[0]["vramGb"]; ok {
 		base["vramGb"] = vramGb
 	}
@@ -3955,6 +3955,36 @@ func toBenchmarkSubmit(payload map[string]any) map[string]any {
 	return out
 }
 
+// normalizeSubmitGpus reshapes each gpus[] entry into the wire shape the
+// localmaxxing.com /api/benchmarks schema expects: { gpuName, count, vramGb }.
+// Accepts legacy entries that used "name" instead of "gpuName".
+func normalizeSubmitGpus(items []any) []any {
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		gpu := asObject(item)
+		if gpu == nil {
+			continue
+		}
+		entry := map[string]any{}
+		if name := firstNonEmpty(stringValue(gpu["gpuName"]), stringValue(gpu["name"])); name != "" {
+			entry["gpuName"] = name
+		}
+		if v := numberField(gpu, "vramGb"); v > 0 {
+			entry["vramGb"] = v
+		}
+		count := numberField(gpu, "count")
+		if count <= 0 {
+			count = numberField(gpu, "gpuCount")
+		}
+		if count <= 0 {
+			count = 1
+		}
+		entry["count"] = int(count)
+		out = append(out, entry)
+	}
+	return out
+}
+
 func remapHardware(hw map[string]any) map[string]any {
 	hwClass := "CPU_ONLY"
 	if firstNonEmpty(stringValue(hw["gpuName"]), stringValue(hw["gpus"])) != "" || len(anySlice(hw["gpus"])) > 0 {
@@ -3974,7 +4004,7 @@ func remapHardware(hw map[string]any) map[string]any {
 			remapped["gpuCount"] = c
 		}
 		if gpus := anySlice(hw["gpus"]); len(gpus) > 0 {
-			remapped["gpus"] = gpus
+			remapped["gpus"] = normalizeSubmitGpus(gpus)
 			delete(remapped, "gpuName")
 			delete(remapped, "vramGb")
 		}

--- a/cmd/lmx/main_test.go
+++ b/cmd/lmx/main_test.go
@@ -40,6 +40,61 @@ func TestApplyNvidiaSMIHardwareParsesMultipleGPUs(t *testing.T) {
 	}
 }
 
+func TestRemapHardwareGpusUsesGpuNameForSubmit(t *testing.T) {
+	hw := map[string]any{
+		"hwClass":  "DISCRETE_GPU",
+		"gpuCount": 2.0,
+		"gpus": []any{
+			map[string]any{"name": "NVIDIA GeForce RTX 4090", "vramGb": 24.0},
+			map[string]any{"gpuName": "NVIDIA GeForce RTX 3090", "vramGb": 24.0, "count": 1.0},
+		},
+		"cpu": "Intel(R) Core(TM) i9-14900K",
+		"os":  "linux",
+	}
+	remapped := remapHardware(hw)
+	if remapped["hwClass"] != "DISCRETE_GPU" {
+		t.Fatalf("hwClass = %v, want DISCRETE_GPU", remapped["hwClass"])
+	}
+	if _, ok := remapped["gpuName"]; ok {
+		t.Fatalf("remapped gpus payload should drop parent gpuName, got %v", remapped["gpuName"])
+	}
+	gpus, ok := remapped["gpus"].([]any)
+	if !ok || len(gpus) != 2 {
+		t.Fatalf("gpus = %#v, want two entries", remapped["gpus"])
+	}
+	first, _ := gpus[0].(map[string]any)
+	if first["gpuName"] != "NVIDIA GeForce RTX 4090" {
+		t.Fatalf("gpus[0].gpuName = %v, want NVIDIA GeForce RTX 4090", first["gpuName"])
+	}
+	if first["count"] != 1 {
+		t.Fatalf("gpus[0].count = %v, want 1", first["count"])
+	}
+	if first["vramGb"] != 24.0 {
+		t.Fatalf("gpus[0].vramGb = %v, want 24.0", first["vramGb"])
+	}
+	if _, leaked := first["name"]; leaked {
+		t.Fatalf("gpus[0] still carries legacy 'name' key: %v", first["name"])
+	}
+}
+
+func TestApplyNvidiaSMIHardwareEmitsGpuName(t *testing.T) {
+	hw := map[string]any{"hwClass": "CPU_ONLY"}
+	applyNvidiaSMIHardware(hw, "NVIDIA GeForce RTX 4090, 24564\n")
+	gpus, ok := hw["gpus"].([]map[string]any)
+	if !ok || len(gpus) != 1 {
+		t.Fatalf("gpus = %#v, want one entry", hw["gpus"])
+	}
+	if gpus[0]["gpuName"] != "NVIDIA GeForce RTX 4090" {
+		t.Fatalf("gpus[0].gpuName = %v, want NVIDIA GeForce RTX 4090", gpus[0]["gpuName"])
+	}
+	if _, leaked := gpus[0]["name"]; leaked {
+		t.Fatalf("gpus[0] should not carry legacy 'name' key")
+	}
+	if hw["gpuName"] != "NVIDIA GeForce RTX 4090" {
+		t.Fatalf("parent gpuName = %v", hw["gpuName"])
+	}
+}
+
 func TestEndpointTimeout(t *testing.T) {
 	defaultTimeout, err := endpointTimeout(cliArgs{opts: map[string]string{}, flags: map[string]bool{}})
 	if err != nil {


### PR DESCRIPTION
The /api/benchmarks Zod schema requires each hardware.gpus[] entry to be { gpuName, count, vramGb }. applyNvidiaSMIHardware was writing the parent-level GPU name into gpus[].name, and remapHardware passed the gpus slice through to the wire unchanged. The discriminated-union validator on the server surfaced the missing gpuName as a confusing "hardware: expected string, received undefined" 400 error.

Producer fix: applyNvidiaSMIHardware now emits gpuName (and count: 1) per entry so freshly generated hardware.json files match the server schema natively.

Wire fix: new normalizeSubmitGpus helper invoked from remapHardware translates each gpus[] entry into the wire shape and accepts legacy "name" keys so existing on-disk hardware.json files still submit cleanly without regenerating.

Locked down with two tests in main_test.go: one for the producer shape and one for the wire shape (including legacy "name" -> "gpuName" translation).